### PR TITLE
Notify channel for build failures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,6 +105,8 @@ lisk_version: ${env.LISK_VERSION}""",
 				extraVars: "devnet: ${params.NETWORK}",
 				throwExceptionWhenFail: false,
 				verbose: false
+
+			liskSlackSend('danger', "Build ${build_info} failed (<${env.BUILD_URL}/console|console>, <${env.BUILD_URL}/changes|changes>)", 'lisk-ci-core')
 		}
 		cleanup {
 			ansibleTower \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,7 +106,7 @@ lisk_version: ${env.LISK_VERSION}""",
 				throwExceptionWhenFail: false,
 				verbose: false
 
-			liskSlackSend('danger', "Build ${build_info} failed (<${env.BUILD_URL}/console|console>, <${env.BUILD_URL}/changes|changes>)", 'lisk-ci-core')
+			liskSlackSend('danger', "Build failed (<${env.BUILD_URL}/console|console>, <${env.BUILD_URL}/changes|changes>)", 'lisk-ci-core')
 		}
 		cleanup {
 			ansibleTower \


### PR DESCRIPTION
### What was the problem?
Whenever the build failed against lisk-core development branch it was not notified to users.
### How did I fix it?
Added slack channel notification on failure